### PR TITLE
feat: switchable embedding backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # similarity_docx
 
 Инструмент для поиска похожих параграфов в документе Microsoft Word (`.docx`).
-Используются эмбеддинги модели [BGE‑M3](https://huggingface.co/BAAI/bge-m3)
-и косинусное сходство.
+По умолчанию используется модель [BGE‑M3](https://huggingface.co/BAAI/bge-m3),
+но через флаги `--backend` и `--model` можно выбрать любую модель из
+`FlagEmbedding` или `sentence-transformers` (например Jina v3, GTE-multilingual,
+Qwen-Embedding).
 
 ## Установка
 
@@ -18,8 +20,16 @@ pip install -r requirements.txt
 python main.py --input myfile.docx --html report.html
 ```
 
+Альтернатива с моделью из `sentence-transformers`:
+
+```bash
+python main.py --input myfile.docx --backend st --model jinaai/jina-embeddings-v3 --html report_jina.html
+```
+
 Полезные параметры:
 
+* `--backend` – бэкенд эмбеддингов (`bge` или `st`).
+* `--model` – название модели.
 * `--threshold` – минимальный порог схожести (по умолчанию `0.88`).
 * `--topk` – сколько кандидатов сравнивать для каждого параграфа (`5`).
 * `--dedupe` – режим удаления дубликатов перед эмбеддингом

--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,9 @@ import tkinter as tk
 from tkinter import filedialog, messagebox, scrolledtext
 
 
-def _run_similarity(docx: Path, threshold: float, log: tk.Text) -> None:
+def _run_similarity(
+    docx: Path, threshold: float, backend: str, model: str, log: tk.Text
+) -> None:
     """Execute :mod:`main` for ``docx`` and append output to ``log``."""
     out_txt = docx.with_suffix(".txt")
     out_html = docx.with_suffix(".html")
@@ -31,6 +33,10 @@ def _run_similarity(docx: Path, threshold: float, log: tk.Text) -> None:
         str(docx),
         "--threshold",
         str(threshold),
+        "--backend",
+        backend,
+        "--model",
+        model,
         "--output",
         str(out_txt),
         "--html",
@@ -56,6 +62,8 @@ def main() -> None:
 
     file_var = tk.StringVar()
     thr_var = tk.DoubleVar(value=0.88)
+    backend_var = tk.StringVar(value="bge")
+    model_var = tk.StringVar(value="BAAI/bge-m3")
 
     def choose_file() -> None:
         fn = filedialog.askopenfilename(filetypes=[("Word", "*.docx")])
@@ -70,7 +78,13 @@ def main() -> None:
         log.delete("1.0", tk.END)
         th = threading.Thread(
             target=_run_similarity,
-            args=(path, float(thr_var.get()), log),
+            args=(
+                path,
+                float(thr_var.get()),
+                backend_var.get(),
+                model_var.get(),
+                log,
+            ),
             daemon=True,
         )
         th.start()
@@ -86,7 +100,15 @@ def main() -> None:
 
     tk.Label(frm, text="Порог схожести:").grid(row=1, column=0, sticky="w")
     tk.Entry(frm, textvariable=thr_var).grid(row=1, column=1, padx=5, sticky="we")
-    tk.Button(frm, text="Старт", command=start).grid(row=1, column=2)
+
+    tk.Label(frm, text="Бэкенд:").grid(row=2, column=0, sticky="w")
+    tk.OptionMenu(frm, backend_var, "bge", "st").grid(row=2, column=1, padx=5, sticky="we")
+
+    tk.Label(frm, text="Модель:").grid(row=3, column=0, sticky="w")
+    tk.Entry(frm, textvariable=model_var, width=50).grid(
+        row=3, column=1, padx=5, sticky="we"
+    )
+    tk.Button(frm, text="Старт", command=start).grid(row=3, column=2)
 
     log = scrolledtext.ScrolledText(root, width=80, height=20)
     log.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)

--- a/embeddings_backends.py
+++ b/embeddings_backends.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import List
+import numpy as np
+
+
+class EmbeddingBackend:
+    """Abstract interface for embedding backends."""
+
+    name: str
+
+    def encode(self, texts: List[str], batch_size: int, max_length: int) -> np.ndarray:
+        """Return a matrix of shape [N, D] as np.float32 without normalization."""
+        raise NotImplementedError
+
+
+class FlagBGEBackend(EmbeddingBackend):
+    def __init__(self, model_name: str, device: str = "auto", fp16: bool = True):
+        try:
+            from FlagEmbedding import BGEM3FlagModel
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError(
+                "Please `pip install FlagEmbedding` to use the BGE backend"
+            ) from e
+
+        self.name = f"flag:{model_name}"
+        self.model = BGEM3FlagModel(model_name, use_fp16=fp16)
+
+    def encode(self, texts: List[str], batch_size: int, max_length: int) -> np.ndarray:
+        out = self.model.encode(
+            texts,
+            batch_size=batch_size,
+            max_length=max_length,
+            return_dense=True,
+            return_sparse=False,
+            return_colbert_vecs=False,
+        )["dense_vecs"]
+        return np.asarray(out, dtype=np.float32, order="C")
+
+
+class STBackend(EmbeddingBackend):
+    def __init__(self, model_name: str, device: str = "auto", trust_remote_code: bool = False):
+        try:
+            from sentence_transformers import SentenceTransformer
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError(
+                "Please `pip install sentence-transformers` to use this backend"
+            ) from e
+
+        if device == "auto":
+            import torch
+
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.model = SentenceTransformer(
+            model_name, device=device, trust_remote_code=trust_remote_code
+        )
+        self.name = f"st:{model_name}"
+
+    def encode(self, texts: List[str], batch_size: int, max_length: int) -> np.ndarray:
+        embs = self.model.encode(
+            texts,
+            batch_size=batch_size,
+            convert_to_numpy=True,
+            normalize_embeddings=False,
+            show_progress_bar=False,
+        )
+        return embs.astype(np.float32, copy=False)
+
+
+def make_backend(
+    kind: str,
+    model_name: str,
+    device: str = "auto",
+    fp16: bool = True,
+    trust_remote_code: bool = False,
+) -> EmbeddingBackend:
+    kind = kind.lower()
+    if kind == "bge":
+        return FlagBGEBackend(model_name=model_name, device=device, fp16=fp16)
+    if kind == "st":
+        return STBackend(
+            model_name=model_name, device=device, trust_remote_code=trust_remote_code
+        )
+    raise ValueError(f"Unknown backend kind: {kind}")


### PR DESCRIPTION
## Summary
- add abstraction for embedding backends with FlagEmbedding and sentence-transformers implementations
- expose CLI flags for backend, model, device and caching metadata
- update GUI and docs to select embedding models

## Testing
- `python -m py_compile embeddings_backends.py main.py __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad827101fc832da1d17397ad70377e